### PR TITLE
Remove keyboard when user taps UITableView

### DIFF
--- a/Classes/LoginViewController.m
+++ b/Classes/LoginViewController.m
@@ -334,6 +334,8 @@
                                           action:@selector(tableViewTapped:)];
     [[self tableView] addGestureRecognizer:tapGesture];
 
+    [tapGesture release];
+
     self.title = @"Login";
     self.tableView.backgroundView = nil;
     self.view.backgroundColor = [UIColor colorWithRed:0.86 green:0.86 blue:0.86 alpha:1.0];


### PR DESCRIPTION
While a user was inputting their username/password, there was no way to cancel
input and dismiss the keyboard unless the user filled out the information and
sent a request to our server. This is pretty annoying to the user. This commit
allows the user to tap outside of the UITableView cells to dismiss the keyboard.
