### PR TITLE
Remove SSL Validation when testing on Cominor

### DIFF
--- a/Classes/iFixitAPI.m
+++ b/Classes/iFixitAPI.m
@@ -243,7 +243,7 @@ static int volatile openConnections = 0;
     NSString *url =	[NSString stringWithFormat:@"https://%@/api/0.1/login", [Config host]];	
 
     __block ASIFormDataRequest *request = [ASIFormDataRequest requestWithURL:[NSURL URLWithString:url]];
-    if ([Config currentConfig].dozuki && [Config currentConfig].site != ConfigMake && [Config currentConfig].site != ConfigIFixit)
+    if ([Config currentConfig].site == ConfigIFixitDev || [Config currentConfig].site == ConfigMakeDev)
         [request setValidatesSecureCertificate:NO];
     [request setRequestMethod:@"POST"];
     [request setPostValue:login forKey:@"login"];
@@ -268,7 +268,7 @@ static int volatile openConnections = 0;
     NSString *url =	[NSString stringWithFormat:@"https://%@/api/0.1/register", [Config currentConfig].host];	
     
     __block ASIFormDataRequest *request = [ASIFormDataRequest requestWithURL:[NSURL URLWithString:url]];    
-    if ([Config currentConfig].dozuki && [Config currentConfig].site != ConfigMake && [Config currentConfig].site != ConfigIFixit)
+    if ([Config currentConfig].site == ConfigIFixitDev || [Config currentConfig].site == ConfigMakeDev)
         [request setValidatesSecureCertificate:NO];
     [request setRequestMethod:@"POST"];
     [request setPostValue:login forKey:@"login"];


### PR DESCRIPTION
We would get SSL Cert issues on cominor, this lets us test on cominor correctly now yay!
