### PR TITLE
Only enable scrolling on WebViews if we need to

### DIFF
--- a/Classes/GuideCatchingWebView.h
+++ b/Classes/GuideCatchingWebView.h
@@ -14,6 +14,6 @@
 @property (nonatomic, assign) UIViewController *modalDelegate;
 @property (nonatomic) BOOL linksOpenInSameWindow;
 
-- (void)shouldEnableScrolling;
+- (void)enableScrollingIfNeeded;
 
 @end

--- a/Classes/GuideCatchingWebView.m
+++ b/Classes/GuideCatchingWebView.m
@@ -117,7 +117,7 @@
         [externalDelegate webViewDidStartLoad:webView];
 }
 
-- (void)shouldEnableScrolling {
+- (void)enableScrollingIfNeeded {
     self.scrollView.scrollEnabled = (self.scrollView.contentSize.height > self.frame.size.height);
 }
 

--- a/Classes/GuideIntroViewController.m
+++ b/Classes/GuideIntroViewController.m
@@ -131,7 +131,7 @@
 // After the content is loaded, we wait a small amount of time before showing it to prevent flicker.
 - (void)webViewDidFinishLoad:(UIWebView *)webView {
     [self performSelector:@selector(showWebView:) withObject:nil afterDelay:0.2];
-    [self.webView shouldEnableScrolling];
+    [self.webView enableScrollingIfNeeded];
 }
 - (void)showWebView:(id)sender {
     webView.hidden = NO;	

--- a/Classes/GuideStepViewController.m
+++ b/Classes/GuideStepViewController.m
@@ -217,7 +217,7 @@
 // After the content is loaded, we wait a small amount of time before showing it to prevent flicker.
 - (void)webViewDidFinishLoad:(UIWebView *)webView {
     [self performSelector:@selector(showWebView:) withObject:nil afterDelay:0.2];
-    [self.webView shouldEnableScrolling];
+    [self.webView enableScrollingIfNeeded];
 }
 - (void)showWebView:(id)sender {
 	webView.hidden = NO;	


### PR DESCRIPTION
Previously on every guide step and guide intro, we made the UIWebView
scrollable (this is the content that displays the bullets and text about each
step). This was annoying to users swiping through guide steps and getting
caught on text that would scroll. This now only enables scrolling if we
need to scroll, Smart Scrolling!
