### PR TITLE
Add transitions when an image is done downloading.

### DIFF
--- a/Classes/GuideIntroViewController.m
+++ b/Classes/GuideIntroViewController.m
@@ -133,7 +133,12 @@
     [self performSelector:@selector(showWebView:) withObject:nil afterDelay:0.2];
 }
 - (void)showWebView:(id)sender {
-    webView.hidden = NO;	
+    [UIView transitionWithView:webView
+                      duration:0.5f
+                       options:UIViewAnimationOptionTransitionCrossDissolve
+                    animations:^{
+                        webView.hidden = NO;
+                    } completion:nil];
 }
 
 - (IBAction)zoomImage:(id)sender {

--- a/Classes/GuideStepViewController.m
+++ b/Classes/GuideStepViewController.m
@@ -180,21 +180,21 @@
 - (void)startImageDownloads {
     
     if ([self.step.images count] > 0) {
-        [mainImage setImageWithURL:[[self.step.images objectAtIndex:0] URLForSize:@"large"] placeholderImage:[UIImage imageNamed:@"collectionsImagePlaceholder.png"]];
+        [mainImage setImageWithURL:[[self.step.images objectAtIndex:0] URLForSize:@"large"] placeholderImage:[UIImage imageNamed:@"NoImage.jpg"]];
         
         if ([self.step.images count] > 1) {
-            [image1 setImageWithURL:[[self.step.images objectAtIndex:0] URLForSize:@"thumbnail"] placeholderImage:[UIImage imageNamed:@"collectionsImagePlaceholder.png"]];
+            [image1 setImageWithURL:[[self.step.images objectAtIndex:0] URLForSize:@"thumbnail"] placeholderImage:[UIImage imageNamed:@"NoImage.jpg"]];
             image1.hidden = NO;
         }
     }
     
     if ([self.step.images count] > 1) {
-        [image2 setImageWithURL:[[self.step.images objectAtIndex:1] URLForSize:@"thumbnail"] placeholderImage:[UIImage imageNamed:@"collectionsImagePlaceholder.png"]];
+        [image2 setImageWithURL:[[self.step.images objectAtIndex:1] URLForSize:@"thumbnail"] placeholderImage:[UIImage imageNamed:@"NoImage.jpg"]];
         image2.hidden = NO;
     }
     
     if ([self.step.images count] > 2) {
-        [image3 setImageWithURL:[[self.step.images objectAtIndex:2] URLForSize:@"thumbnail"] placeholderImage:[UIImage imageNamed:@"collectionsImagePlaceholder.png"]];
+        [image3 setImageWithURL:[[self.step.images objectAtIndex:2] URLForSize:@"thumbnail"] placeholderImage:[UIImage imageNamed:@"NoImage.jpg"]];
         image3.hidden = NO;
     }
 }
@@ -210,7 +210,7 @@
         guideImage = [self.step.images objectAtIndex:2];
 
     // Switch to the new image, but delay the spinner for a short time.
-    [mainImage setImageWithURL:[guideImage URLForSize:@"large"] placeholderImage:[UIImage imageNamed:@"collectionsImagePlaceholder.png"]];
+    [mainImage setImageWithURL:[guideImage URLForSize:@"large"] placeholderImage:[UIImage imageNamed:@"NoImage.jpg"]];
 }
 
 // Because the web view has a white background, it starts hidden.

--- a/Classes/SDWebImage/UIButton+WebCache.m
+++ b/Classes/SDWebImage/UIButton+WebCache.m
@@ -38,7 +38,14 @@
 
 - (void)webImageManager:(SDWebImageManager *)imageManager didFinishWithImage:(UIImage *)image
 {
-    [self setBackgroundImage:image forState:UIControlStateNormal];
+    if (image) {
+        [UIView transitionWithView:self
+                          duration:0.5f
+                           options:UIViewAnimationOptionTransitionCrossDissolve
+                        animations:^{
+                            [self setBackgroundImage:image forState:UIControlStateNormal];
+                        } completion:nil];
+    }
 }
 
 @end

--- a/Classes/SDWebImage/UIImageView+WebCache.m
+++ b/Classes/SDWebImage/UIImageView+WebCache.m
@@ -32,8 +32,14 @@
 }
 
 - (void)webImageManager:(SDWebImageManager *)imageManager didFinishWithImage:(UIImage *)image {
-    if (image)
-        self.image = image;
+    if (image) {
+        [UIView transitionWithView:self
+                          duration:0.5f
+                           options:UIViewAnimationOptionTransitionCrossDissolve
+                        animations:^{
+                            self.image = image;
+                        } completion:nil];
+    }
 }
 
 @end


### PR DESCRIPTION
We initially show the No Ruler image, then once the image finishes downloading we replace it with the downloaded thumbnail. Nothing is wrong with that, it just doesn't seem to be smooth. This pull adds a transition when an image is done downloading and needs to be replaced, which makes for a much smoother experience. We apply this now to almost anywhere we are getting an Image or HTML from our own API.
