### PR TITLE
Fix Favorites controller animation/behavior

### DIFF
--- a/Classes/BookmarksViewController.m
+++ b/Classes/BookmarksViewController.m
@@ -191,8 +191,16 @@
 }
 
 - (void)doneButtonPushed {
-    // Use deprecated method for 4.3+ support
-    [self dismissModalViewControllerAnimated:YES];
+    // Create the animation ourselves to mimic a modal presentation
+    if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+        [UIView animateWithDuration:0.7
+                         animations:^{
+                             [UIView setAnimationTransition:UIViewAnimationTransitionCurlDown forView:self.navigationController.view cache:YES];
+                         }];
+        [self.navigationController popViewControllerAnimated:NO];
+    } else {
+        [self dismissModalViewControllerAnimated:YES];
+    }
 }
 
 - (void)viewDidUnload

--- a/Classes/ListViewController.m
+++ b/Classes/ListViewController.m
@@ -86,13 +86,24 @@
 
 - (void)favoritesButtonPushed {
     BookmarksViewController *bvc = [[BookmarksViewController alloc] initWithNibName:@"BookmarksView" bundle:nil];
-    UINavigationController *nvc = [[UINavigationController alloc] initWithRootViewController:bvc];
     
-    // Use deprecated method on purpose to preserve iOS 4.3
-    [self presentModalViewController:nvc animated:YES];
-    
+    // Create the animation ourselves to mimic a modal presentation
+    // On iPad we must push the view onto a stack, instead of presenting
+    // it modally or else undesired side effects occur
+    if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
+        [UIView animateWithDuration:0.7
+                         animations:^{
+                             [self pushViewController:bvc animated:NO];
+                             [UIView setAnimationTransition:UIViewAnimationTransitionCurlUp forView:self.view cache:YES];
+                         }];
+    else {
+        UINavigationController *nvc = [[UINavigationController alloc] initWithRootViewController:bvc];
+        
+        [self presentModalViewController:nvc animated:YES];
+        [nvc release];
+    }
+        
     [bvc release];
-    [nvc release];
 }
 
 @end


### PR DESCRIPTION
Before on iPad when a user selected the favorites button, it would appear
across the whole screen, instead it only appears on the first view of the split
view controller.

For iPad I also added a curl up animation to mimic a modal presentation, when
really I am pushing the view on and off the navigation stack.

on iPhone we just use a simple modal presentation so I don't have to recreate
the animations.
