### PR TITLE
Fix GuideView Loading/unloading View controllers

### DIFF
--- a/Classes/CategoriesViewController.m
+++ b/Classes/CategoriesViewController.m
@@ -506,7 +506,8 @@
 - (void)modifyTypesForGuides:(NSArray*)guides {
     for (id guide in guides) {
         guide[@"type"] = @(GUIDE);
-        guide[@"name"] = guide[@"title"];
+        // If we update to 2.0, check for subject, then default back to title if subject DNE
+        guide[@"name"] = guide[@"subject"];
     }
 }
 

--- a/Classes/GuideViewController.m
+++ b/Classes/GuideViewController.m
@@ -269,9 +269,12 @@
     CGFloat pageWidth = scrollView.frame.size.width;
     int page = floor((scrollView.contentOffset.x - pageWidth / 2) / pageWidth) + 1;
     pageControl.currentPage = page;
-	
-    // load the visible page and the page on either side of it (to avoid flashes when the user starts scrolling)
-    //[self performSelector:@selector(preloadForCurrentPage:) withObject:[NSNumber numberWithInt:page] afterDelay:0.1];
+}
+
+// At the begin of scroll dragging, reset the boolean used when scrolls originate from the UIPageControl
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
+    int page = pageControl.currentPage;
+    pageControlUsed = NO;
     [self preloadForCurrentPage:[NSNumber numberWithInt:page]];
 	
     // Unload the views+controllers which are no longer visible
@@ -289,18 +292,17 @@
    }
 }
 
-// At the begin of scroll dragging, reset the boolean used when scrolls originate from the UIPageControl
-- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
-    pageControlUsed = NO;
-}
-
 // At the end of scroll animation, reset the boolean used when scrolls originate from the UIPageControl
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
     pageControlUsed = NO;
+    
+    // If the user scrolls super fast, a view controller may be null, this will load the page if we come across that behavior
+    if ([viewControllers[pageControl.currentPage] isKindOfClass:[NSNull class]]) {
+        [self scrollViewWillBeginDragging:scrollView];
+    }
 }
 
 - (IBAction)changePage:(id)sender {
-
     int page = pageControl.currentPage;
 	
     // load the visible page and the page on either side of it (to avoid flashes when the user starts scrolling)


### PR DESCRIPTION
We have logic where we destroy view controllers we are no longer using
or we need to create view controllers. This logic was originally in a delegate
method called "scrollViewDidScroll". Problem is this delegate method can be
called upwards of 20+ times per step, so maybe that logic shouldn't have been thrown in
this delegate method. Instead, I moved it to the correct delegate method that
gets called only once.

TLDR; Method that does expensive things used to be called 20+ times per step,
when it should have only been called once. This fixes that.

Also another small change I made is to use the guide's subject instead of title when viewing guides in the category list. This is for consistency
