### PR TITLE
Guide photos cannot be zoomed out enough to fit on screen

### DIFF
--- a/Classes/GuideImageViewController.h
+++ b/Classes/GuideImageViewController.h
@@ -16,6 +16,7 @@
 
 @property (nonatomic, assign) id delegate;
 @property (nonatomic, retain) UIScrollView *imageScrollView;
+@property (nonatomic, retain) UIImageView *imageView;
 @property (nonatomic, retain) UIImage *image;
 @property (nonatomic, retain) NSDate *delay;
 

--- a/Classes/GuideImageViewController.m
+++ b/Classes/GuideImageViewController.m
@@ -70,8 +70,13 @@ static CGRect frameView;
     [[delegate delegate] willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
 }
 
+- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
+    [imageScrollView setZoomScale:1.0 animated:YES];
+    imageView.frame = imageScrollView.frame;
+}
+
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
-    imageScrollView.contentSize = imageView.frame.size;
+    [imageScrollView setZoomScale:1.0 animated:YES];
 }
 
 - (void)loadView {

--- a/Classes/GuideImageViewController.m
+++ b/Classes/GuideImageViewController.m
@@ -79,7 +79,7 @@ static CGRect frameView;
     [[UIApplication sharedApplication] setStatusBarHidden:YES];
 
     // set up main scroll view
-	self.imageScrollView = [[[UIScrollView alloc] initWithFrame:self.view.frame] autorelease];
+	self.imageScrollView = [[[UIScrollView alloc] initWithFrame:self.view.bounds] autorelease];
     imageScrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [imageScrollView setBackgroundColor:[Config currentConfig].backgroundColor];
     [imageScrollView setDelegate:self];

--- a/Classes/GuideImageViewController.m
+++ b/Classes/GuideImageViewController.m
@@ -96,7 +96,6 @@ static CGRect frameView;
 
     // add touch-sensitive image view to the scroll view
 	self.imageView = [[[UIImageView alloc] initWithFrame:imageScrollView.bounds] autorelease];
-    imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     imageView.image = self.image;
     imageView.contentMode = UIViewContentModeScaleAspectFit;
     [imageView setUserInteractionEnabled:YES];

--- a/Classes/GuideImageViewController.m
+++ b/Classes/GuideImageViewController.m
@@ -85,6 +85,7 @@ static CGRect frameView;
     [imageScrollView setBackgroundColor:[Config currentConfig].backgroundColor];
     [imageScrollView setDelegate:self];
     [imageScrollView setBouncesZoom:YES];
+    [imageScrollView setMaximumZoomScale:2.0];
     [self.view addSubview:imageScrollView];
 	[self.view sendSubviewToBack:imageScrollView];
 
@@ -94,8 +95,6 @@ static CGRect frameView;
     imageView.image = self.image;
     [imageView setUserInteractionEnabled:YES];
 	[imageScrollView addSubview:imageView];
-    
-    [imageScrollView setMaximumZoomScale:2.0];
    
     [self setupTouchEvents];
     

--- a/Classes/GuideImageViewController.m
+++ b/Classes/GuideImageViewController.m
@@ -9,9 +9,6 @@
 #import "GuideImageViewController.h"
 #import "Config.h"
 
-#define ZOOM_VIEW_TAG 100
-
-
 @interface GuideImageViewController (UtilityMethods)
 - (CGRect)zoomRectForScale:(float)scale withCenter:(CGPoint)center;
 @end
@@ -19,7 +16,7 @@
 
 @implementation GuideImageViewController
 
-@synthesize delegate, image, imageScrollView, delay;
+@synthesize delegate, image, imageScrollView, imageView, delay;
 
 static CGRect frameView;
 
@@ -88,9 +85,8 @@ static CGRect frameView;
 	[self.view sendSubviewToBack:imageScrollView];
 
     // add touch-sensitive image view to the scroll view
-	UIImageView *imageView = [[UIImageView alloc] initWithImage:self.image];
+	self.imageView = [[UIImageView alloc] initWithImage:self.image];
 
-    [imageView setTag:ZOOM_VIEW_TAG];
     [imageView setUserInteractionEnabled:YES];
     //[imageScrollView setContentSize:[imageView frame].size];
     imageView.frame = CGRectMake(0.0, 0.0, 1600.0, 1200.0);
@@ -111,7 +107,7 @@ static CGRect frameView;
     CGRect zoomRect = [self zoomRectForScale:minimumScale withCenter:center];
     [imageScrollView zoomToRect:zoomRect animated:NO];
    
-    [self setupTouchEvents:imageView];
+    [self setupTouchEvents];
     
     self.delay = [NSDate date];
     
@@ -127,7 +123,7 @@ static CGRect frameView;
     [self.view addSubview:back];
        
 }
-- (void)setupTouchEvents:(UIImageView *)imageView {
+- (void)setupTouchEvents {
    
    // add gesture recognizers to the image view
    UITapGestureRecognizer *singleTapG = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTap:)];
@@ -150,6 +146,7 @@ static CGRect frameView;
 - (void)dealloc {
     [image release];
     [imageScrollView release];
+    [imageView release];
     [delay release];
     
     [super dealloc];
@@ -158,7 +155,7 @@ static CGRect frameView;
 #pragma mark UIScrollViewDelegate methods
 
 - (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView {
-    return [imageScrollView viewWithTag:ZOOM_VIEW_TAG];
+    return imageView;
 }
 
 #pragma mark TapDetectingImageViewDelegate methods

--- a/Classes/GuideImageViewController.m
+++ b/Classes/GuideImageViewController.m
@@ -70,6 +70,10 @@ static CGRect frameView;
     [[delegate delegate] willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
 }
 
+- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
+    imageScrollView.contentSize = imageView.frame.size;
+}
+
 - (void)loadView {
     [super loadView];
     
@@ -85,25 +89,13 @@ static CGRect frameView;
 	[self.view sendSubviewToBack:imageScrollView];
 
     // add touch-sensitive image view to the scroll view
-	self.imageView = [[[UIImageView alloc] initWithImage:self.image] autorelease];
+	self.imageView = [[[UIImageView alloc] initWithFrame:imageScrollView.bounds] autorelease];
+    imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    imageView.image = self.image;
     [imageView setUserInteractionEnabled:YES];
-    //[imageScrollView setContentSize:[imageView frame].size];
-    imageView.frame = CGRectMake(0.0, 0.0, 1600.0, 1200.0);
-    [imageScrollView setContentSize:CGSizeMake(1600.0f, 1200.0f)];
 	[imageScrollView addSubview:imageView];
-   
-    // calculate minimum scale to perfectly fit longer edge, and begin at that scale
-    float minimumWidthScale = [imageScrollView frame].size.width / [imageView frame].size.width;
-    float minimumHeightScale = [imageScrollView frame].size.height / [imageView frame].size.height;
-    float minimumScale = fmax(minimumWidthScale, minimumHeightScale);
     
-    [imageScrollView setMinimumZoomScale:minimumScale];
-    [imageScrollView setZoomScale:minimumScale];
     [imageScrollView setMaximumZoomScale:2.0];
-   
-    CGPoint center = CGPointMake(0, 0);
-    CGRect zoomRect = [self zoomRectForScale:minimumScale withCenter:center];
-    [imageScrollView zoomToRect:zoomRect animated:NO];
    
     [self setupTouchEvents];
     

--- a/Classes/GuideImageViewController.m
+++ b/Classes/GuideImageViewController.m
@@ -85,14 +85,12 @@ static CGRect frameView;
 	[self.view sendSubviewToBack:imageScrollView];
 
     // add touch-sensitive image view to the scroll view
-	self.imageView = [[UIImageView alloc] initWithImage:self.image];
-
+	self.imageView = [[[UIImageView alloc] initWithImage:self.image] autorelease];
     [imageView setUserInteractionEnabled:YES];
     //[imageScrollView setContentSize:[imageView frame].size];
     imageView.frame = CGRectMake(0.0, 0.0, 1600.0, 1200.0);
     [imageScrollView setContentSize:CGSizeMake(1600.0f, 1200.0f)];
 	[imageScrollView addSubview:imageView];
-    [imageView release];
    
     // calculate minimum scale to perfectly fit longer edge, and begin at that scale
     float minimumWidthScale = [imageScrollView frame].size.width / [imageView frame].size.width;

--- a/Classes/GuideImageViewController.m
+++ b/Classes/GuideImageViewController.m
@@ -93,6 +93,7 @@ static CGRect frameView;
 	self.imageView = [[[UIImageView alloc] initWithFrame:imageScrollView.bounds] autorelease];
     imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     imageView.image = self.image;
+    imageView.contentMode = UIViewContentModeScaleAspectFit;
     [imageView setUserInteractionEnabled:YES];
 	[imageScrollView addSubview:imageView];
    


### PR DESCRIPTION
This is a fix for a bug listed in #26:

> When viewing a guide photo full screen you can't zoom out so the photo fills the screen, despite the aspect ratio appearing to match.

This fix ensures that you can always zoom out far enough that the entire photo is on screen, regardless of the device orientation and the aspect ratio of the photo.